### PR TITLE
Step 2 — Set Babel’s IE target from 9 to 11

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,6 +3,10 @@
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
 
+const babelIE11 = require('./patch/babelIE11');
+const babelConfig = require('babel-preset-react-app');
+babelIE11(babelConfig);
+
 const webpackPreact = require('./patch/webpackPreact');
 const webpackConfig = require('react-scripts/config/webpack.config.prod');
 webpackPreact(webpackConfig);

--- a/scripts/patch/babelIE11.js
+++ b/scripts/patch/babelIE11.js
@@ -1,0 +1,14 @@
+// Hack babel to build for IE11 instead of IE9
+module.exports = babelConfig => {
+	const presets = babelConfig.presets;
+	presets.forEach((preset, i) => {
+		if (!Array.isArray(preset)) {
+			return;
+		}
+		preset.forEach((p, j) => {
+			if (p.targets && p.targets.ie) {
+				presets[i][j].ie = 11;
+			}
+		});
+	});
+};

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,6 +3,10 @@
 process.env.BABEL_ENV = 'development';
 process.env.NODE_ENV = 'development';
 
+const babelIE11 = require('./patch/babelIE11');
+const babelConfig = require('babel-preset-react-app');
+babelIE11(babelConfig);
+
 const webpackPreact = require('./patch/webpackPreact');
 const webpackConfig = require('react-scripts/config/webpack.config.dev');
 webpackPreact(webpackConfig);


### PR DESCRIPTION
We don't need to support IE8 & IE9 anymore…

> This is how you can modify `babel`'s target settings, not just IE ;)

The same way it was possible to change the `webpack` config, we're going to do just that to `babel`.

Files sizes remain the same because there are no 'fancy' methods used in the `preact` code so it compiles just the same on IE9 and IE11.